### PR TITLE
Installation fixes

### DIFF
--- a/application/controllers/SettingsController.php
+++ b/application/controllers/SettingsController.php
@@ -422,13 +422,18 @@ class SettingsController extends TrapsController
   {
       $psOutput=array();
       // First check is someone is listening to port 162. As not root, we can't have pid... 
-      exec('netstat -an |grep -E "udp.*:162"',$psOutput);
+      $sspath = '/usr/sbin/ss';
+      if(!is_executable("$sspath"))
+      {
+          return array(1,"Can not execute $sspath");
+      }
+      exec("$sspath -luna | grep ':162 '",$psOutput);
       if (count($psOutput) == 0)
       {
-          return array(1,'Port UDP/162 is not open : snmptrapd must not be started');
+          return array(1,'Port UDP/162 is not open : is snmptrapd running?');
       }
       $psOutput=array();
-      exec('ps fax |grep snmptrapd |grep -v grep',$psOutput);
+      exec('ps --no-headers -o command -C snmptrapd',$psOutput);
       if (count($psOutput) == 0)
       {
           return array(1,"UDP/162 : OK, but no snmptrapd process (?)");

--- a/application/controllers/SettingsController.php
+++ b/application/controllers/SettingsController.php
@@ -427,7 +427,7 @@ class SettingsController extends TrapsController
       {
           return array(1,"Can not execute $sspath");
       }
-      exec("$sspath -luna | grep ':162 '",$psOutput);
+      exec("$sspath -lun | grep ':162 '",$psOutput);
       if (count($psOutput) == 0)
       {
           return array(1,'Port UDP/162 is not open : is snmptrapd running?');

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -236,7 +236,7 @@ function check_snmptrapd_run() {
 		echo "Returned : $ret"
 		echo "Waiting 5 sec to come up"
 		sleep 5
-		port=$(ss -pluna | grep ':162 ' 2>&1)
+		port=$(ss -plun | grep ':162 ' | head -1 2>&1)
 		if [ $? -ne 0 ]; then
 			echo 'snmptrapd started but not listening to udp/162.... Exiting...'
 			return 0;

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -225,7 +225,7 @@ function check_snmptrapd_run() {
 	echo
 	
 	# Check port 
-	port=$(ss -pluna | grep ':162 ' 2>&1)
+	port=$(ss -plun | grep ':162 ' | head -1 2>&1)
 	if [ $? -ne 0 ]; then
 		echo 'No process is listening on port 162, trying to start it.'
 		ret=$(systemctl start snmptrapd)

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -244,7 +244,7 @@ function check_snmptrapd_run() {
 	fi
 	
 	# get pid 
-	snmpPid=$( echo $port | grep -oP '(?<=pid=)[0-9]+' );
+	snmpPid=$( echo $port | sed -r 's/.*pid=([0-9]+).*/\1/' );
 	snmpName=$( echo $port | grep -oP '(?<=")[\w]+' );
 	echo "Found process $snmpName with pid $snmpPid"
 

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -245,7 +245,7 @@ function check_snmptrapd_run() {
 	
 	# get pid 
 	snmpPid=$( echo $port | sed -r 's/.*pid=([0-9]+).*/\1/' );
-	snmpName=$( echo $port | grep -oP '(?<=")[\w]+' );
+	snmpName=$( echo $port | sed -r 's/.*\("([^"]+)".*/\1/' );
 	echo "Found process $snmpName with pid $snmpPid"
 
 	# get options


### PR DESCRIPTION
### application/controllers/SettingsController.php
1. Replaced `netstat` with `ss`. Fixes module configuration not being able to find a listening snmptrapd port if `netstat` isn't installed. (note: `netstat` is not part of a minimal CentOS install, but `ss` is).

2. Inform the user if `/usr/sbin/ss` can't be found/executed.

3. Improved the listening port error message. "snmptrapd must not be started" could have been incorrectly interpreted as "you should stop snmptrapd".

4. Cleaned up `ps` command for neatness.

### bin/installer.sh
1. Use `awk` instead of `cut` to avoid leading whitespace in `$icingaEtc`. Leading whitespace caused "apiusers" grep to fail.

2. Replaced `netstat` with `ss` as per above.
