### PR TITLE
only try /usr/sbin/ss if ss can not be found in the search path

### DIFF
--- a/application/controllers/SettingsController.php
+++ b/application/controllers/SettingsController.php
@@ -422,7 +422,12 @@ class SettingsController extends TrapsController
   {
       $psOutput=array();
       // First check is someone is listening to port 162. As not root, we can't have pid... 
-      $sspath = '/usr/sbin/ss';
+      $sspath = exec('which ss 2>/dev/null');
+      if(empty($sspath))
+      {
+          // RHEL based systems
+          $sspath = '/usr/sbin/ss';
+      }
       if(!is_executable("$sspath"))
       {
           return array(1,"Can not execute $sspath");


### PR DESCRIPTION
I overlooked path compatibility in #34. Sorry for that. This PR restores support for non RHEL based systems.