### PR TITLE
Update SettingsController.php

### DIFF
--- a/application/controllers/SettingsController.php
+++ b/application/controllers/SettingsController.php
@@ -11,7 +11,7 @@ use Exception;
 
 use Icinga\Module\Trapdirector\TrapsController;
 use Icinga\Module\Trapdirector\Forms\TrapsConfigForm;
-use Icinga\Module\Trapdirector\Icinga2API;
+use Icinga\Module\Trapdirector\Icinga2Api;
 use Icinga\Module\Trapdirector\TrapsActions\DBException;
 
 use Trapdirector\Trap;


### PR DESCRIPTION
Capital issue - setup wizard wont work because `trapdirector/library/Trapdirector/Icinga2Api.php ` is not capital
```

Uncaught Error: Class 'Icinga\Module\Trapdirector\Icinga2API' not found in /usr/share/icingaweb2/modules/trapdirector/application/controllers/SettingsController.php:135
Stack trace:
#0 /usr/share/icingaweb2/modules/trapdirector/application/controllers/SettingsController.php(254): Icinga\Module\Trapdirector\Controllers\SettingsController->check_api()
#1 /usr/share/icingaweb2/library/vendor/Zend/Controller/Action.php(507): Icinga\Module\Trapdirector\Controllers\SettingsController->indexAction()
#2 /usr/share/php/Icinga/Web/Controller/Dispatcher.php(76): Zend_Controller_Action->dispatch('indexAction')
#3 /usr/share/icingaweb2/library/vendor/Zend/Controller/Front.php(937): Icinga\Web\Controller\Dispatcher->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#4 /usr/share/php/Icinga/Application/Web.php(300): Zend_Controller_Front->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#5 /usr/share/php/Icinga/Application/webrouter.php(99): Icinga\Application\Web->dispatch()
#6 /usr/share/i

#0 [internal function]: Icinga\Application\Web->Icinga\Application\{closure}()
#1 {main}
```