### PR TITLE
Fix issue with updating traps

### DIFF
--- a/library/Trapdirector/TrapsProcess/MibDatabase.php
+++ b/library/Trapdirector/TrapsProcess/MibDatabase.php
@@ -80,7 +80,7 @@ trait MibDatabase
                 ':syntax' => $this->oidDesc['syntax']==null??'null',
                 ':type_enum' => $this->oidDesc['type_enum']??'null',
                 ':description' => $this->oidDesc['description']??'null',
-                ':id' => $this->dbOidAll[$this->dbOidIndex[$this->oidDesc['oid']]['id']]
+                ':id' => $this->dbOidIndex[$this->oidDesc['oid']]['id']
             );
             
             if ($sqlQuery->execute($sqlParam) === false) {


### PR DESCRIPTION
Fix an "array to string" conversion problem for traps that are already present in the database. Usually seen as "Error in update : Array to string conversion", with an aborted import / update of mibs as a result.

The issue I've come across that this fixes is that instead of passing an entire array to the ":id", it now passes just the ID's to make the query work instead of aborting the process.

On the next run regardless of this fix, the code thinks the trap is already imported if it has already been attempted to be imported before and skips it. This ticket does not fix that issue.