### PR TITLE
Replace deprecated getConnection with getDbAdapter

### DIFF
--- a/application/controllers/HandlerController.php
+++ b/application/controllers/HandlerController.php
@@ -32,7 +32,7 @@ class HandlerController extends TrapsController
 		      $this->moduleConfig->getHandlerListTitles(),
 		      $this->moduleConfig->getHandlerListDisplayColumns(),
 		      $this->moduleConfig->getHandlerColumns(),
-		      $dbConn->getConnection(),
+		      $dbConn->getDbAdapter(),
 		      $this->view,
 		      $this->moduleConfig->urlPath());
 		

--- a/library/Trapdirector/TrapsActions/UIDatabase.php
+++ b/library/Trapdirector/TrapsActions/UIDatabase.php
@@ -224,7 +224,7 @@ class UIDatabase //extends TrapDBQuery
     public function getDbConn()
     {
         if ($this->getDb() == null) return null;
-        return $this->getDb()->getConnection();
+        return $this->getDb()->getDbAdapter();
     }
     
     /**


### PR DESCRIPTION
In [Icinga Web 2.11.x](https://icinga.com/docs/icinga-web/latest/doc/80-Upgrading/#upgrading-to-icinga-web-211x) there have been framework changes (see link, Framework changes affecting third-party code)
This requires changing some functions. I replaced getConnection() with getDbAdapter() and it fixed the issue I had,
#70 
So far, I could only test the change on the current Icinga Web version, and it fixed the problem. The new function was available for some time, so it should work with older Icinga Web versions too, but I have no old installation available to test for now.

